### PR TITLE
Fix peerDependencies react-dom version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react": "^17.0.2 || ^18.2.0",
     "react-dnd": "^14.0.2",
     "react-dnd-html5-backend": "^14.0.0",
-    "react-dom": "17.0.2 || ^18.2.0"
+    "react-dom": "^17.0.2 || ^18.2.0"
   },
   "dependencies": {
     "classnames": "~2.3.1",


### PR DESCRIPTION

```
npm ERR! Found: react-dom@17.1.2
npm ERR! node_modules/react-dom
npm ERR!   react-dom@"npm:@preact/compat@17.1.2" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react-dom@"17.0.2 || ^18.2.0" from react-tag-input@0.0.0-semantically-released
```